### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,16 @@
     "test": "mocha",
     "build": "webpack"
   },
-  "keywords": [],
+  "keywords": [
+    "拼音",
+    "chinese",
+    "pinyin",
+    "match"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/xmflswood/pinyin-match.git"
+  },
   "author": "774898896@qq.com",
   "license": "ISC",
   "devDependencies": {


### PR DESCRIPTION
npmjs.org 上的信息页面没有代码库信息，想找这个包的 GitHub 页面还得手动在 GitHub 上搜索，挺麻烦的。

![2020-04-26 18-17-50 的屏幕截图](https://user-images.githubusercontent.com/1730073/80304695-43ee2900-87ea-11ea-87c3-5b1860290fe4.png)

所以，做出如下改动：

- 更新 keywords 字段
- 添加 repository 字段
